### PR TITLE
fix: export `useSigner` `useSignMessage` `useSignTypedData`

### DIFF
--- a/packages/vagmi/src/composables/accounts/index.ts
+++ b/packages/vagmi/src/composables/accounts/index.ts
@@ -3,3 +3,6 @@ export { useConnect } from './useConnect';
 export { useDisconnect } from './useDisconnect';
 export { useNetwork } from './useNetwork';
 export { useBalance } from './useBalance';
+export { useSigner } from './useSigner'
+export { useSignMessage } from './useSignMessage'
+export { useSignTypedData } from './useSignTypedData'

--- a/packages/vagmi/src/composables/index.ts
+++ b/packages/vagmi/src/composables/index.ts
@@ -4,6 +4,9 @@ export {
   useDisconnect,
   useNetwork,
   useBalance,
+  useSigner,
+  useSignMessage,
+  useSignTypedData
 } from './accounts';
 
 export { useProvider, useWebSocketProvider } from './providers';

--- a/packages/vagmi/src/index.ts
+++ b/packages/vagmi/src/index.ts
@@ -22,6 +22,9 @@ export {
   useEnsAvatar,
   useBlockNumber,
   useFeeData,
+  useSigner,
+  useSignMessage,
+  useSignTypedData
 } from './composables';
 
 export {


### PR DESCRIPTION
I suggest you can check automatically delete head branches in `Settings -> General -> Automatically delete head branches`.