### PR TITLE
add `useWaitForTransaction` support & export all types & fix useProvider bug

### DIFF
--- a/packages/vagmi/src/composables/index.ts
+++ b/packages/vagmi/src/composables/index.ts
@@ -24,3 +24,7 @@ export {
   useEnsResolver,
   useEnsAvatar,
 } from './ens';
+
+export {
+  useWaitForTransaction,
+} from './transactions';

--- a/packages/vagmi/src/composables/providers/useProvider.ts
+++ b/packages/vagmi/src/composables/providers/useProvider.ts
@@ -1,9 +1,8 @@
 import type { providers } from 'ethers';
 import type { GetProviderArgs } from '@wagmi/core';
 import { getProvider, watchProvider } from '@wagmi/core';
-import { klona } from 'klona/json';
 
-import { readonly, ref, watchEffect } from 'vue';
+import { markRaw, readonly, ref, watchEffect } from 'vue';
 import type { SetMaybeRef } from '../../types';
 import { getMaybeRefValue } from '../../utils';
 
@@ -12,11 +11,12 @@ export type UseProviderArgs = SetMaybeRef<Partial<GetProviderArgs>>;
 export function useProvider<TProvider extends providers.BaseProvider>({
   chainId,
 }: UseProviderArgs = {}) {
-  const provider = ref(klona(getProvider<TProvider>({ chainId: getMaybeRefValue(chainId) })));
+
+  const provider = ref(markRaw(getProvider<TProvider>({ chainId: getMaybeRefValue(chainId) })));
 
   watchEffect((onInvalidate) => {
     const unwatch = watchProvider<TProvider>({ chainId: getMaybeRefValue(chainId) }, (provider_) => {
-      provider.value = klona(provider_);
+      provider.value = markRaw(provider_);
     });
 
     onInvalidate(() => {

--- a/packages/vagmi/src/composables/transactions/index.ts
+++ b/packages/vagmi/src/composables/transactions/index.ts
@@ -1,0 +1,1 @@
+export { useWaitForTransaction } from './useWaitForTransaction'

--- a/packages/vagmi/src/composables/transactions/useWaitForTransaction.test.ts
+++ b/packages/vagmi/src/composables/transactions/useWaitForTransaction.test.ts
@@ -1,0 +1,119 @@
+import { actConnect, renderComposable } from '../../../test'
+import { useConnect } from '../accounts'
+import {
+  UseWaitForTransactionArgs,
+  UseWaitForTransactionConfig,
+  useWaitForTransaction,
+} from './useWaitForTransaction'
+
+function useWaitForTransactionWithConnect(
+  config: UseWaitForTransactionArgs & UseWaitForTransactionConfig = {},
+) {
+  return {
+    connect: useConnect(),
+    waitForTransaction: useWaitForTransaction(config),
+  }
+}
+
+describe('useWaitForTransaction', () => {
+  it('mounts', () => {
+    const { result } = renderComposable(() => useWaitForTransaction())
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { internal, ...res } = result
+    expect(res).toMatchInlineSnapshot(`
+      {
+        "data": undefined,
+        "error": null,
+        "fetchStatus": "idle",
+        "isError": false,
+        "isFetched": false,
+        "isFetching": false,
+        "isIdle": true,
+        "isLoading": false,
+        "isRefetching": false,
+        "isSuccess": false,
+        "refetch": [Function],
+        "status": "idle",
+      }
+    `)
+  })
+
+  describe('configuration', () => {
+    it('chainId,', async () => {
+      const hash = '0x6825f7848a2d92e2788cb660ef57d22add152c8c70817c6a62ed58d97bead7c9'
+      const utils = renderComposable(() =>
+        useWaitForTransactionWithConnect({
+          chainId: 1,
+          hash,
+        }),
+      )
+      const { nextTick, result, waitFor } = utils
+      await actConnect({ utils })
+
+      nextTick()
+
+      await waitFor(() =>
+        expect(result.waitForTransaction.isSuccess).toBeTruthy(),
+      )
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { data, internal, ...res } = result.waitForTransaction
+      expect(data).toBeDefined()
+      expect(data.value?.transactionHash).toEqual(hash)
+      expect(res).toMatchInlineSnapshot(`
+        {
+          "error": null,
+          "fetchStatus": "idle",
+          "isError": false,
+          "isFetched": true,
+          "isFetching": false,
+          "isIdle": false,
+          "isLoading": false,
+          "isRefetching": false,
+          "isSuccess": true,
+          "refetch": [Function],
+          "status": "success",
+        }
+      `)
+    })
+
+    it('hash', async () => {
+      const hash = '0x6825f7848a2d92e2788cb660ef57d22add152c8c70817c6a62ed58d97bead7c9'
+      const utils = renderComposable(() =>
+        useWaitForTransactionWithConnect({
+          hash,
+        }),
+      )
+      
+      const { nextTick, result, waitFor } = utils
+      
+      await actConnect({ utils })
+
+      nextTick()
+
+      await waitFor(() =>
+        expect(result.waitForTransaction.isSuccess).toBeTruthy(),
+      )
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { data, internal, ...res } = result.waitForTransaction
+      expect(data).toBeDefined()
+      expect(data.value?.transactionHash).toEqual(hash)
+      expect(res).toMatchInlineSnapshot(`
+        {
+          "error": null,
+          "fetchStatus": "idle",
+          "isError": false,
+          "isFetched": true,
+          "isFetching": false,
+          "isIdle": false,
+          "isLoading": false,
+          "isRefetching": false,
+          "isSuccess": true,
+          "refetch": [Function],
+          "status": "success",
+        }
+      `)
+    })
+  })
+})

--- a/packages/vagmi/src/composables/transactions/useWaitForTransaction.ts
+++ b/packages/vagmi/src/composables/transactions/useWaitForTransaction.ts
@@ -1,0 +1,72 @@
+import { get } from '@vueuse/core'
+import {
+    WaitForTransactionArgs,
+    WaitForTransactionResult,
+    waitForTransaction,
+  } from '@wagmi/core'
+  
+  import { QueryConfig, QueryFunctionArgs } from '../../types'
+  import { useChainId, useQuery } from '../utils'
+  
+  export type UseWaitForTransactionArgs = Partial<WaitForTransactionArgs>
+  
+  export type UseWaitForTransactionConfig = QueryConfig<
+    WaitForTransactionResult,
+    Error
+  >
+  
+  export const queryKey = ({
+    confirmations,
+    chainId,
+    hash,
+    timeout,
+    wait,
+  }: Partial<WaitForTransactionArgs>) =>
+    [
+      {
+        entity: 'waitForTransaction',
+        confirmations,
+        chainId,
+        hash,
+        timeout,
+        wait,
+      },
+    ] as const
+  
+  const queryFn = ({
+    queryKey: [{ chainId, confirmations, hash, timeout, wait }],
+  }: QueryFunctionArgs<typeof queryKey>) => {
+    return waitForTransaction({ chainId, confirmations, hash, timeout, wait })
+  }
+  
+  export function useWaitForTransaction({
+    chainId: chainId_,
+    confirmations,
+    hash,
+    timeout,
+    wait,
+    cacheTime,
+    enabled = true,
+    staleTime,
+    suspense,
+    onError,
+    onSettled,
+    onSuccess,
+  }: UseWaitForTransactionArgs & UseWaitForTransactionConfig = {}) {
+
+    const chainId = useChainId({ chainId: chainId_ })
+    
+    return useQuery(
+      queryKey({ chainId: get(chainId), confirmations, hash, timeout, wait }),
+      queryFn,
+      {
+        cacheTime,
+        enabled: Boolean(enabled && (hash || wait)),
+        staleTime,
+        suspense,
+        onError,
+        onSettled,
+        onSuccess,
+      },
+    )
+  }

--- a/packages/vagmi/src/index.ts
+++ b/packages/vagmi/src/index.ts
@@ -24,7 +24,8 @@ export {
   useFeeData,
   useSigner,
   useSignMessage,
-  useSignTypedData
+  useSignTypedData,
+  useWaitForTransaction,
 } from './composables';
 
 export {
@@ -49,3 +50,10 @@ export type {
   Storage,
   Unit,
 } from '@wagmi/core';
+
+export type {
+  QueryFunctionArgs,
+  SetMaybeRef,
+  QueryConfig,
+  MutationConfig,
+} from './types';


### PR DESCRIPTION
`useProvider` use the klona to deep clone will be triggering an error `Maximum call stack size exceeded error`
i replace the klona with markRaw to fix it

@wobsoriano 